### PR TITLE
Code stabilization

### DIFF
--- a/Competition/.vscode/settings.json
+++ b/Competition/.vscode/settings.json
@@ -60,6 +60,22 @@
     "type_traits": "cpp",
     "tuple": "cpp",
     "typeinfo": "cpp",
-    "utility": "cpp"
+    "utility": "cpp",
+    "hash_map": "cpp",
+    "hash_set": "cpp",
+    "bitset": "cpp",
+    "list": "cpp",
+    "unordered_set": "cpp",
+    "algorithm": "cpp",
+    "iterator": "cpp",
+    "map": "cpp",
+    "memory_resource": "cpp",
+    "numeric": "cpp",
+    "random": "cpp",
+    "set": "cpp",
+    "string": "cpp",
+    "future": "cpp",
+    "iomanip": "cpp",
+    "cinttypes": "cpp"
   }
 }

--- a/Competition/src/main/cpp/RobotContainer.cpp
+++ b/Competition/src/main/cpp/RobotContainer.cpp
@@ -16,11 +16,11 @@ RobotContainer::RobotContainer() {
         [this] { return m_GamepadDriver.GetX(frc::GenericHID::kLeftHand); },
         [this] { return m_GamepadDriver.GetBumper(frc::GenericHID::kLeftHand); }));
 
-    m_arm.SetDefaultCommand(ArmManual(m_arm, 
-        [this] { return m_GamepadDriver.GetY(frc::GenericHID::kLeftHand); }));
+    // m_arm.SetDefaultCommand(ArmManual(m_arm, 
+    //     [this] { return m_GamepadDriver.GetY(frc::GenericHID::kLeftHand); }));
 
-    m_lift.SetDefaultCommand(Climb(m_lift, 
-        [this] { return m_GamepadDriver.GetY(frc::GenericHID::kRightHand); }));
+    // m_lift.SetDefaultCommand(Climb(m_lift, 
+    //     [this] { return m_GamepadDriver.GetY(frc::GenericHID::kRightHand); }));
 
     // Configure the button bindings
     ConfigureButtonBindings();

--- a/Competition/src/main/cpp/RobotContainer.cpp
+++ b/Competition/src/main/cpp/RobotContainer.cpp
@@ -27,41 +27,24 @@ RobotContainer::RobotContainer() {
 }
 
 void RobotContainer::ConfigureButtonBindings() {
-    frc2::JoystickButton driver_rightBumper{&m_GamepadDriver, 6};
-    frc2::JoystickButton driver_leftBumper{&m_GamepadDriver, 5};
-
-    frc2::JoystickButton driver_start{&m_GamepadDriver, 8};
-    frc2::JoystickButton driver_back{&m_GamepadDriver, 7};
-
-    frc2::JoystickButton operator_start{&m_GamepadOperator, 8};
-    frc2::JoystickButton operator_back{&m_GamepadOperator, 7};
-    frc2::JoystickButton operator_leftBumper{&m_GamepadOperator, 5};
-    frc2::JoystickButton operator_rightBumper{&m_GamepadOperator, 6};
 
     frc2::JoystickButton driver_a{&m_GamepadDriver, 1};
     frc2::JoystickButton driver_b{&m_GamepadDriver, 2};
     frc2::JoystickButton driver_x{&m_GamepadDriver, 3};
+    frc2::JoystickButton driver_y{&m_GamepadDriver, 4};
+    frc2::JoystickButton driver_leftBumper{&m_GamepadDriver, 5};
+    frc2::JoystickButton driver_rightBumper{&m_GamepadDriver, 6};
+    frc2::JoystickButton driver_back{&m_GamepadDriver, 7};
+    frc2::JoystickButton driver_start{&m_GamepadDriver, 8};
 
-    frc2::JoystickButton operator_y{&m_GamepadOperator, 4};
+    frc2::JoystickButton operator_a{&m_GamepadOperator, 1};
     frc2::JoystickButton operator_b{&m_GamepadOperator, 2};
-
-    //for running drivetrain for 8 min
-    // driver_a.WhenPressed(DriveManual(m_drivetrain,
-    //     [this] { return 1; },
-    //     [this] { return 0; },
-    //     [this] { return 0; },
-    //     [this] { return false; }));
-    // driver_x.WhenPressed(DriveManual(m_drivetrain,
-    //     [this] { return 0; },
-    //     [this] { return 1; },
-    //     [this] { return 0; },
-    //     [this] { return false; }));
-    // driver_b.WhenPressed(DriveManual(m_drivetrain,
-    //     [this] { return 0; },
-    //     [this] { return 0; },
-    //     [this] { return 0; },
-    //     [this] { return false; }));
-
+    frc2::JoystickButton operator_x{&m_GamepadOperator, 3};
+    frc2::JoystickButton operator_y{&m_GamepadOperator, 4};
+    frc2::JoystickButton operator_leftBumper{&m_GamepadOperator, 5};
+    frc2::JoystickButton operator_rightBumper{&m_GamepadOperator, 6};
+    frc2::JoystickButton operator_back{&m_GamepadOperator, 7};
+    frc2::JoystickButton operator_start{&m_GamepadOperator, 8};
 
     driver_rightBumper.WhenPressed(frc2::InstantCommand([&] { m_drivetrain.SetMultiplier(1); }, {&m_drivetrain}));
     driver_rightBumper.WhenReleased(frc2::InstantCommand([&] { m_drivetrain.SetMultiplier(0.5); }, {&m_drivetrain}));
@@ -69,11 +52,8 @@ void RobotContainer::ConfigureButtonBindings() {
     driver_leftBumper.WhenPressed(frc2::InstantCommand([&] { m_intake.SetIntakePower(0.5); m_hopper.SetHopperPower(0.5); }));
     driver_leftBumper.WhenReleased(frc2::InstantCommand([&] { m_intake.SetIntakePower(0); m_hopper.SetHopperPower(0); }));
 
-    // operator_start.WhenPressed(frc2::InstantCommand([&] { m_shooter.SetShooterPower(1); }, {&m_shooter}));
-    // operator_back.WhenPressed(frc2::InstantCommand([&] { m_shooter.SetShooterPower(0); }, {&m_shooter}));
-
-    driver_start.WhenPressed(frc2::InstantCommand([&] { m_shooter.SetShooterPower(1); }, {&m_shooter}));
-    driver_back.WhenPressed(frc2::InstantCommand([&] { m_shooter.SetShooterPower(0); }, {&m_shooter}));
+    operator_start.WhenPressed(frc2::InstantCommand([&] { m_shooter.SetShooterPower(1); }, {&m_shooter}));
+    operator_back.WhenPressed(frc2::InstantCommand([&] { m_shooter.SetShooterPower(0); }, {&m_shooter}));
 
     operator_leftBumper.WhenPressed(frc2::InstantCommand([&] { m_intake.SetIntakePower(0.5); }, {&m_intake}));
     operator_leftBumper.WhenReleased(frc2::InstantCommand([&] { m_intake.SetIntakePower(0); }, {&m_intake}));

--- a/Competition/src/main/cpp/RobotContainer.cpp
+++ b/Competition/src/main/cpp/RobotContainer.cpp
@@ -60,8 +60,8 @@ void RobotContainer::ConfigureButtonBindings() {
     operator_rightBumper.WhenPressed(frc2::InstantCommand([&] { m_intake.SetIntakePower(-0.5); }, {&m_intake}));
     operator_rightBumper.WhenReleased(frc2::InstantCommand([&] { m_intake.SetIntakePower(0); }, {&m_intake}));
     
-    operator_y.WhenPressed(frc2::InstantCommand([&] { m_muncher.SetMunchPower(1); }, {&m_muncher}));
-    operator_y.WhenPressed(frc2::InstantCommand([&] { m_muncher.SetMunchPower(0); }, {&m_muncher}));
+    // operator_y.WhenPressed(frc2::InstantCommand([&] { m_muncher.SetMunchPower(1); }, {&m_muncher}));
+    // operator_y.WhenPressed(frc2::InstantCommand([&] { m_muncher.SetMunchPower(0); }, {&m_muncher}));
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/Competition/src/main/cpp/subsystems/Arm.cpp
+++ b/Competition/src/main/cpp/subsystems/Arm.cpp
@@ -1,6 +1,6 @@
 #include "subsystems/Arm.h"
 
-Arm::Arm() : leftArmMtr{ArmConstants::TALON_ID_LEFT_ARM}, rightArmMtr{ArmConstants::TALON_ID_RIGHT_ARM} {
+Arm::Arm() : leftArmMtr{ArmConstants::CAN_ID_LEFT_ARM}, rightArmMtr{ArmConstants::CAN_ID_RIGHT_ARM} {
     
 }
 
@@ -15,5 +15,6 @@ void Arm::Periodic() {
 }
 
 void Arm::SetArmPower(double power) {
-    armMtrs.Set(power);
+    leftArmMtr.Set(ControlMode::PercentOutput, power*0.25);
+    rightArmMtr.Set(ControlMode::PercentOutput, power*0.25);
 }

--- a/Competition/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/Competition/src/main/cpp/subsystems/Drivetrain.cpp
@@ -81,9 +81,8 @@ void Drivetrain::InitDrives(rev::CANSparkMax::IdleMode idleMode) {
     m_leftPIDController.SetSmartMotionMaxAccel(DriveConstants::kMaxAccel);
     m_leftPIDController.SetSmartMotionAllowedClosedLoopError(DriveConstants::kAllError);
 
-    // leftDrive.SetInverted(false);
-    // rightDrive.SetInverted(true);
-    //rightDrive.SetInverted(!rightDrive.GetInverted());
+    m_leftDriveLead.SetInverted(false);
+    m_rightDriveLead.SetInverted(true);
 }
 
 void Drivetrain::ResetEncoders() {

--- a/Competition/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/Competition/src/main/cpp/subsystems/Drivetrain.cpp
@@ -57,29 +57,29 @@ void Drivetrain::InitDrives(rev::CANSparkMax::IdleMode idleMode) {
     m_rightDriveFollowA.Follow(m_rightDriveLead);
     m_rightDriveFollowB.Follow(m_rightDriveLead);
 
-    m_leftPIDController.SetP(kP);
-    m_leftPIDController.SetI(kI);
-    m_leftPIDController.SetD(kD);
-    m_leftPIDController.SetIZone(kIz);
-    m_leftPIDController.SetFF(kFF);
-    m_leftPIDController.SetOutputRange(kMinOutput, kMaxOutput);
+    m_leftPIDController.SetP(DriveConstants::kP);
+    m_leftPIDController.SetI(DriveConstants::kI);
+    m_leftPIDController.SetD(DriveConstants::kD);
+    m_leftPIDController.SetIZone(DriveConstants::kIz);
+    m_leftPIDController.SetFF(DriveConstants::kFF);
+    m_leftPIDController.SetOutputRange(DriveConstants::kMinOutput, DriveConstants::kMaxOutput);
 
-    m_rightPIDController.SetP(kP);
-    m_rightPIDController.SetI(kI);
-    m_rightPIDController.SetD(kD);
-    m_rightPIDController.SetIZone(kIz);
-    m_rightPIDController.SetFF(kFF);
-    m_rightPIDController.SetOutputRange(kMinOutput, kMaxOutput);
+    m_rightPIDController.SetP(DriveConstants::kP);
+    m_rightPIDController.SetI(DriveConstants::kI);
+    m_rightPIDController.SetD(DriveConstants::kD);
+    m_rightPIDController.SetIZone(DriveConstants::kIz);
+    m_rightPIDController.SetFF(DriveConstants::kFF);
+    m_rightPIDController.SetOutputRange(DriveConstants::kMinOutput, DriveConstants::kMaxOutput);
 
-    m_rightPIDController.SetSmartMotionMaxVelocity(kMaxVel);
-    m_rightPIDController.SetSmartMotionMinOutputVelocity(kMinVel);
-    m_rightPIDController.SetSmartMotionMaxAccel(kMaxAccel);
-    m_rightPIDController.SetSmartMotionAllowedClosedLoopError(kAllError);
+    m_rightPIDController.SetSmartMotionMaxVelocity(DriveConstants::kMaxVel);
+    m_rightPIDController.SetSmartMotionMinOutputVelocity(DriveConstants::kMinVel);
+    m_rightPIDController.SetSmartMotionMaxAccel(DriveConstants::kMaxAccel);
+    m_rightPIDController.SetSmartMotionAllowedClosedLoopError(DriveConstants::kAllError);
     
-    m_leftPIDController.SetSmartMotionMaxVelocity(kMaxVel);
-    m_leftPIDController.SetSmartMotionMinOutputVelocity(kMinVel);
-    m_leftPIDController.SetSmartMotionMaxAccel(kMaxAccel);
-    m_leftPIDController.SetSmartMotionAllowedClosedLoopError(kAllError);
+    m_leftPIDController.SetSmartMotionMaxVelocity(DriveConstants::kMaxVel);
+    m_leftPIDController.SetSmartMotionMinOutputVelocity(DriveConstants::kMinVel);
+    m_leftPIDController.SetSmartMotionMaxAccel(DriveConstants::kMaxAccel);
+    m_leftPIDController.SetSmartMotionAllowedClosedLoopError(DriveConstants::kAllError);
 
     // leftDrive.SetInverted(false);
     // rightDrive.SetInverted(true);
@@ -148,27 +148,27 @@ void Drivetrain::ArcadeDrive(double leftInput, double rightInput) {
 
 void Drivetrain::RocketLeagueDrive(double straightInput, double reverseInput, double turnInput, bool limelightInput) {
     straightValue = reverseInput - straightInput;
-    if (std::abs(straightValue) < kDeadbandY) {
+    if (std::abs(straightValue) < DriveConstants::kDeadbandY) {
       straightValue = 0;
     }
     directionY = (straightValue > 0) ? 1 : -1;
-    straightTarget = MaxRPM * -std::pow(straightValue, 2) * directionY * kDriveMultiplierY * boostMultiplier;
+    straightTarget = DriveConstants::MaxRPM * -std::pow(straightValue, 2) * directionY * DriveConstants::kDriveMultiplierY * boostMultiplier;
    
     turnValue = turnInput;
 
     directionX = (turnValue >= 0) ? 1 : -1;
-    turnValue = -std::pow(turnValue * kDriveMultiplierX, 2) * directionX;
-    turnTarget = MaxRPM * turnValue;
+    turnValue = -std::pow(turnValue * DriveConstants::kDriveMultiplierX, 2) * directionX;
+    turnTarget = DriveConstants::MaxRPM * turnValue;
     if (directionY == 1) {   //for inverting x and y in revese direction
       turnTarget = -turnTarget;
     }
     
-    if (std::abs(turnValue) < kDeadbandX) {
-      if (std::abs(straightValue) < kDeadbandY) {
+    if (std::abs(turnValue) < DriveConstants::kDeadbandX) {
+      if (std::abs(straightValue) < DriveConstants::kDeadbandY) {
         turnTarget = 0; //if turning, don't use drive straightening
       }
       else {
-        turnTarget = (m_leftEncoder.GetVelocity() - m_rightEncoder.GetVelocity()) * kDriveOffset;
+        turnTarget = (m_leftEncoder.GetVelocity() - m_rightEncoder.GetVelocity()) * DriveConstants::kDriveOffset;
         // Robot tends to curve to the left at 50RPM slower
       }
     }
@@ -178,7 +178,7 @@ void Drivetrain::RocketLeagueDrive(double straightInput, double reverseInput, do
     float tv = table->GetNumber("tv" , 0.0);
 
     if (limelightInput && tv == 1) {
-      turnTarget = kP * tx * MaxRPM;
+      turnTarget = DriveConstants::kP * tx * DriveConstants::MaxRPM;
     }
   
     m_leftPIDController.SetReference(straightTarget - turnTarget, rev::ControlType::kVelocity);

--- a/Competition/src/main/cpp/subsystems/Hopper.cpp
+++ b/Competition/src/main/cpp/subsystems/Hopper.cpp
@@ -1,7 +1,7 @@
 #include "subsystems/Hopper.h"
 
-Hopper::Hopper() : hopperMtr{HopperConstants::VICTOR_ID_HOPPER_A},
-                   throatMtr{ShooterConstants::VICTOR_ID_THROAT} {
+Hopper::Hopper() : hopperMtr{HopperConstants::PWM_ID_HOPPER},
+                   throatMtr{ShooterConstants::PWM_ID_THROAT} {
     InitHopper();
 }
 

--- a/Competition/src/main/cpp/subsystems/Intake.cpp
+++ b/Competition/src/main/cpp/subsystems/Intake.cpp
@@ -2,7 +2,7 @@
 
 
 
-Intake::Intake() : intakeMtr{IntakeConstants::VICTOR_ID_INTAKE} {
+Intake::Intake() : intakeMtr{IntakeConstants::PWM_ID_INTAKE} {
     //intakeMtr.SetInverted();
 }
 

--- a/Competition/src/main/cpp/subsystems/Lift.cpp
+++ b/Competition/src/main/cpp/subsystems/Lift.cpp
@@ -1,6 +1,6 @@
 #include "subsystems/Lift.h"
 
-Lift::Lift() : liftMtrA{LiftConstants::VICTOR_ID_LIFT_A}/*, liftMtrB{LiftConstants::VICTOR_ID_LIFT_B} */{
+Lift::Lift() : liftMtrA{LiftConstants::PWM_ID_LIFT_A}, liftMtrB{LiftConstants::PWM_ID_LIFT_B} {
     
 }
 
@@ -15,6 +15,6 @@ void Lift::Periodic() {
 }
 
 void Lift::SetLiftPower(double power) {
-    //liftMtrs.Set(power);
     liftMtrA.Set(power);
+    liftMtrB.Set(power);
 }

--- a/Competition/src/main/cpp/subsystems/Muncher.cpp
+++ b/Competition/src/main/cpp/subsystems/Muncher.cpp
@@ -1,6 +1,6 @@
 #include "subsystems/Muncher.h"
 
-Muncher::Muncher() : muncherMtr{MuncherConstants::VICTOR_ID_MUNCHER} {
+Muncher::Muncher() : muncherMtr{MuncherConstants::PWM_ID_MUNCHER} {
 
 }
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -30,6 +30,24 @@ namespace DriveConstants {
     constexpr double kWheelDiameterInches = 6;
     constexpr double kGearRatio = 8.8;
 
+    constexpr static double kP = 0.01f;
+    constexpr static double kI = 0.0;
+    constexpr static double kD = 0.0;
+    constexpr static double kIz = 0.0;
+    constexpr static double kFF = 0.0001754;
+    constexpr static double MaxRPM = 5700;
+    constexpr static double kMaxOutput = 1.0;
+    constexpr static double kMinOutput = -1.0;
+    constexpr static double kMaxVel = 1000;
+    constexpr static double kMinVel = 0;
+    constexpr static double kMaxAccel = 1500;
+    constexpr static double kAllError = 0;
+    constexpr static double kDeadband = 0.05;
+    constexpr static double kDeadbandY = 0.02;
+    constexpr static double kDeadbandX = 0.02;
+    constexpr static double kDriveMultiplierX = 0.5;
+    constexpr static double kDriveMultiplierY = 1;
+    constexpr static double kDriveOffset = 1;
 }
 
 namespace RamseteConstants {

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -60,8 +60,8 @@ namespace RamseteConstants {
 
 namespace ArmConstants {
 
-    constexpr static int TALON_ID_LEFT_ARM = 6;
-    constexpr static int TALON_ID_RIGHT_ARM = 1;
+    constexpr static int CAN_ID_LEFT_ARM = 9;
+    constexpr static int CAN_ID_RIGHT_ARM = 10;
 
 }
 
@@ -69,33 +69,35 @@ namespace ShooterConstants {
 
     constexpr static int CAN_ID_SHOOTER_LEAD = 7;
     constexpr static int CAN_ID_SHOOTER_FOLLOW = 8;
-    constexpr static int VICTOR_ID_THROAT = 0;
-    constexpr static int PWM_ID_HOOD = 0;
+    constexpr static int PWM_ID_THROAT = 0;
+    constexpr static int PWM_ID_HOOD = 6;
 
 }
 
 namespace IntakeConstants {
 
-    constexpr static int VICTOR_ID_INTAKE = 1;
+    constexpr static int PWM_ID_INTAKE = 1;
 
 }
 
 namespace HopperConstants {
 
-    constexpr static int VICTOR_ID_HOPPER_A = 2;
+    constexpr static int PWM_ID_HOPPER = 2;
 
 }
 
 namespace LiftConstants {
 
-    constexpr static int VICTOR_ID_LIFT_A = 5;
-    //constexpr static int VICTOR_ID_LIFT_B = 8;
+    constexpr static int PWM_ID_LIFT_A = 3;
+    constexpr static int PWM_ID_LIFT_B = 5;
+    constexpr static int PWM_ID_LEFT_A_SERVO_LOCK = 7;
+    constexpr static int PWM_ID_LEFT_B_SERVO_LOCK = 7;
 
 }
 
 namespace MuncherConstants {
 
-    constexpr static int VICTOR_ID_MUNCHER = 4;
+    constexpr static int PWM_ID_MUNCHER = 4;
 
 }
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -76,7 +76,7 @@ namespace ShooterConstants {
 
 namespace IntakeConstants {
 
-    constexpr static int VICTOR_ID_INTAKE = 3;
+    constexpr static int VICTOR_ID_INTAKE = 1;
 
 }
 

--- a/Competition/src/main/include/subsystems/Arm.h
+++ b/Competition/src/main/include/subsystems/Arm.h
@@ -5,7 +5,7 @@
 #include <rev/CANSparkMax.h>
 #include "Constants.h"
 #include <frc/SpeedControllerGroup.h>
-#include <frc/PWMVictorSPX.h>
+#include <ctre/Phoenix.h>
 #include <units/units.h>
 
 #ifndef ARM_H
@@ -27,12 +27,12 @@ class Arm/* : public frc2::ProfiledPIDSubsystem<units::degrees>*/ : public frc2:
  private:
 
      // talons
-     frc::PWMVictorSPX leftArmMtr;
-     frc::PWMVictorSPX rightArmMtr;
+     TalonSRX leftArmMtr;
+     TalonSRX rightArmMtr;
 
      // 2 servos
 
-     frc::SpeedControllerGroup armMtrs{leftArmMtr, rightArmMtr};
+    //  frc::SpeedControllerGroup armMtrs{leftArmMtr, rightArmMtr};
 
     // add 2 encoders for arm
 

--- a/Competition/src/main/include/subsystems/Drivetrain.h
+++ b/Competition/src/main/include/subsystems/Drivetrain.h
@@ -28,25 +28,6 @@
 #ifndef DRIVETRAIN_H
 #define DRIVETRAIN_H
 
-#define kP -0.01f
-#define kI 0
-#define kD 0
-#define kIz 0
-#define kFF 1.0/MaxRPM
-#define MaxRPM 5700
-#define kMaxOutput 1.0
-#define kMinOutput -1.0
-#define kMaxVel 1000
-#define kMinVel 0
-#define kMaxAccel 1500
-#define kAllError 0
-#define kDeadband 0.05
-#define kDeadbandY 0.02
-#define kDeadbandX 0.02
-#define kDriveMultiplierX 0.5
-#define kDriveMultiplierY 1
-#define kDriveOffset 1
-
 class Drivetrain : public frc2::SubsystemBase{
  public:
 

--- a/Competition/src/main/include/subsystems/Lift.h
+++ b/Competition/src/main/include/subsystems/Lift.h
@@ -21,7 +21,7 @@ class Lift : public frc2::SubsystemBase {
  private:
 
     frc::PWMVictorSPX liftMtrA;
-    //frc::PWMVictorSPX liftMtrB;
+    frc::PWMVictorSPX liftMtrB;
 
     //frc::SpeedControllerGroup liftMtrs{liftMtrA, liftMtrB};
 

--- a/Competition/vendordeps/Phoenix.json
+++ b/Competition/vendordeps/Phoenix.json
@@ -1,0 +1,180 @@
+{
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix",
+    "version": "5.18.2",
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "http://devsite.ctr-electronics.com/maven/release/"
+    ],
+    "jsonUrl": "http://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.18.2"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.18.2"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.18.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "diagnostics",
+            "version": "5.18.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.18.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-stub",
+            "version": "5.18.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "core",
+            "version": "5.18.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.18.2",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.18.2",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.18.2",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "diagnostics",
+            "version": "5.18.2",
+            "libName": "CTRE_PhoenixDiagnostics",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.18.2",
+            "libName": "CTRE_PhoenixCanutils",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-stub",
+            "version": "5.18.2",
+            "libName": "CTRE_PhoenixPlatform",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "core",
+            "version": "5.18.2",
+            "libName": "CTRE_PhoenixCore",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Looking through the latest set of commits, we have necessary commits on multiple branches.

Sifted through each branch and pulled out mandatory code that needs to go on `dev` IMMEDIATELY for safety reasons, as well as some code on `dev` no longer matches our wiring diagram.

# Functionality

Following things will be functional with this PR:
* Left and right drives on chassis (rocket league controls)
  * Boost
  * Turn
  * Drive straightening
  * Limelight tracking
* Shooting balls
* Intaking balls
* Reversing intake if need be

Following things are commented out and can be uncommented for testing:
* Telescoping arm manual control
* Rotational arm manual control
* Muncher

## Control scheme (current)
![image](https://user-images.githubusercontent.com/6731455/75493024-9e9c0d80-597e-11ea-913d-c43271992ce6.png)

![image](https://user-images.githubusercontent.com/6731455/75493029-a2c82b00-597e-11ea-8025-689e8bc5b105.png)

## Wiring diagram (current)
![image](https://user-images.githubusercontent.com/6731455/75493048-af4c8380-597e-11ea-8f65-2af60ad340e0.png)

![image](https://user-images.githubusercontent.com/6731455/75493063-b96e8200-597e-11ea-818c-cbc796a42845.png)
