### PR TITLE
Switched A and B assignments to Left and Right

### DIFF
--- a/Competition/src/main/cpp/RobotContainer.cpp
+++ b/Competition/src/main/cpp/RobotContainer.cpp
@@ -17,10 +17,10 @@ RobotContainer::RobotContainer() {
         [this] { return m_GamepadDriver.GetBumper(frc::GenericHID::kLeftHand); }));
 
     // m_arm.SetDefaultCommand(ArmManual(m_arm, 
-    //     [this] { return m_GamepadDriver.GetY(frc::GenericHID::kLeftHand); }));
+    //     [this] { return m_GamepadOperator.GetY(frc::GenericHID::kLeftHand); }));
 
     // m_lift.SetDefaultCommand(Climb(m_lift, 
-    //     [this] { return m_GamepadDriver.GetY(frc::GenericHID::kRightHand); }));
+    //     [this] { return m_GamepadOperator.GetY(frc::GenericHID::kRightHand); }));
 
     // Configure the button bindings
     ConfigureButtonBindings();

--- a/Competition/src/main/cpp/subsystems/Lift.cpp
+++ b/Competition/src/main/cpp/subsystems/Lift.cpp
@@ -1,6 +1,6 @@
 #include "subsystems/Lift.h"
 
-Lift::Lift() : liftMtrA{LiftConstants::PWM_ID_LIFT_A}, liftMtrB{LiftConstants::PWM_ID_LIFT_B} {
+Lift::Lift() : liftMtrLeft{LiftConstants::PWM_ID_LIFT_LEFT}, liftMtrRight{LiftConstants::PWM_ID_LIFT_RIGHT} {
     
 }
 
@@ -15,6 +15,6 @@ void Lift::Periodic() {
 }
 
 void Lift::SetLiftPower(double power) {
-    liftMtrA.Set(power);
-    liftMtrB.Set(power);
+    liftMtrLeft.Set(power);
+    liftMtrRight.Set(power);
 }

--- a/Competition/src/main/cpp/subsystems/Shooter.cpp
+++ b/Competition/src/main/cpp/subsystems/Shooter.cpp
@@ -2,7 +2,8 @@
 
 Shooter::Shooter() : shootMtrLeft{ShooterConstants::CAN_ID_SHOOTER_LEAD, rev::CANSparkMax::MotorType::kBrushless}, 
                      shootMtrRight{ShooterConstants::CAN_ID_SHOOTER_FOLLOW, rev::CANSparkMax::MotorType::kBrushless}, 
-                     hood{ShooterConstants::PWM_ID_HOOD} {
+                     hood_left{ShooterConstants::PWM_ID_HOOD_LEFT},
+                     hood_right{ShooterConstants::PWM_ID_HOOD_RIGHT} {
     InitShooter(rev::CANSparkMax::IdleMode::kCoast);
 }
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -88,7 +88,8 @@ namespace ShooterConstants {
     constexpr static int CAN_ID_SHOOTER_LEAD = 7;
     constexpr static int CAN_ID_SHOOTER_FOLLOW = 8;
     constexpr static int PWM_ID_THROAT = 0;
-    constexpr static int PWM_ID_HOOD = 6;
+    constexpr static int PWM_ID_HOOD_LEFT = 6;
+    constexpr static int PWM_ID_HOOD_RIGHT = 9;
 
 }
 
@@ -106,10 +107,10 @@ namespace HopperConstants {
 
 namespace LiftConstants {
 
-    constexpr static int PWM_ID_LIFT_A = 3;
-    constexpr static int PWM_ID_LIFT_B = 5;
-    constexpr static int PWM_ID_LEFT_A_SERVO_LOCK = 7;
-    constexpr static int PWM_ID_LEFT_B_SERVO_LOCK = 7;
+    constexpr static int PWM_ID_LIFT_LEFT = 3;
+    constexpr static int PWM_ID_LIFT_RIGHT = 5;
+    constexpr static int PWM_ID_LIFT_LEFT_SERVO_LOCK = 7;
+    constexpr static int PWM_ID_LIFT_RIGHT_SERVO_LOCK = 8;
 
 }
 

--- a/Competition/src/main/include/subsystems/Lift.h
+++ b/Competition/src/main/include/subsystems/Lift.h
@@ -20,8 +20,8 @@ class Lift : public frc2::SubsystemBase {
 
  private:
 
-    frc::PWMVictorSPX liftMtrA;
-    frc::PWMVictorSPX liftMtrB;
+    frc::PWMVictorSPX liftMtrLeft;
+    frc::PWMVictorSPX liftMtrRight;
 
     //frc::SpeedControllerGroup liftMtrs{liftMtrA, liftMtrB};
 

--- a/Competition/src/main/include/subsystems/Shooter.h
+++ b/Competition/src/main/include/subsystems/Shooter.h
@@ -26,8 +26,8 @@ class Shooter : public frc2::SubsystemBase {
     
     frc::SpeedControllerGroup shootMtrs{shootMtrLeft, shootMtrRight};
     
-
-    frc::Servo hood;
+    frc::Servo hood_left;
+    frc::Servo hood_right;
 
 };
 


### PR DESCRIPTION
Avoid confusion in the code for left and right motors or hoods